### PR TITLE
Make frontend responsive, add ability to use service without e2ee, support hi-dpi 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -189,7 +189,7 @@ function App() {
 
   return (
     <div className="flex">
-      <div className="md:w-2/3 lg:w-3/4 xl:w-4/5 w-screen" ref={editorContainerRef} >
+      <div className="md:w-2/3 lg:w-3/4 xl:w-4/5 2xl:w-5/6 w-screen" ref={editorContainerRef} >
         <CodeMirror
           autoFocus={true}
           value={document}
@@ -201,7 +201,7 @@ function App() {
           onChange={onDocumentChange}
         />
       </div>
-      <div className='md:block md:w-1/3 lg:w-1/4 xl:w-1/5 hidden'>
+      <div className='md:block md:w-1/3 lg:w-1/4 xl:w-1/5 2xl:w-1/6 hidden'>
         <MenuBar duplicateAndEdit={onDuplicateAndEdit} id={readOnly ? params.id : undefined} alert={alert} loading={loading} readOnly={readOnly} save={onSave} ephemeral={{ ephemeral, setEphemeral }} language={{ language, setLanguage }} theme={{ theme, setTheme }} font={{ fontSize, setFontSize }} wrapLine={{ wrapLine, setWrapLine }} />
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import axios from 'axios';
 import { Extension } from "@codemirror/state";
 import CodeMirror from '@uiw/react-codemirror';
 import { useEffect, useRef, useState } from 'react';
-import { EditorView, ViewUpdate } from "@codemirror/view";
+import { EditorView } from "@codemirror/view";
 import { useNavigate, useParams } from "react-router-dom";
 import { duotoneDark } from '@uiw/codemirror-theme-duotone';
 
@@ -15,23 +14,25 @@ import NavBar from './navbar/navbar'
 import getFontSizeThemeExtension from './fonts'
 import useWindowDimensions from './dimensions';
 import { handleLanguageChange, handleThemeChange } from './dynamic-loader';
-// TODO: Chunk Loading for Crypto
-import { aeadDecrypt, aeadEncrypt, CryptoStack, generateEncryptionStack, getSnippetUUID, SnippetSpecModel } from './crypto/crypto';
-import { environment } from './environment';
+import { E2EService } from './service/e2e';
+import { RestService } from './service/rest';
+import { ServiceInterface } from './service/model';
 
 function App() {
   const navigate = useNavigate()
   let params = useParams();
   let [editorWidth, setEditorWidth] = useState<number>(0)
+  let [editorHeight, setEditorHeight] = useState<number>(0)
   const editorContainerRef = useRef<HTMLDivElement>(null)
   let [readOnly, setReadOnly] = useState<boolean>(false)
   let [loading, setLoading] = useState<boolean>(false)
   let [alert, setAlert] = useState<string>('')
   let [dismisser, setDismisser] = useState<NodeJS.Timeout | undefined>()
+  let [desktopView, setDesktopView] = useState<boolean>(false)
   // Editor State Properties 
   let [generateStack, setGenerateStack] = useState<boolean>(false)
-  // TODO: Load and save to browser localStorage
   let [wrapLine, setWrapLine] = useState<boolean>(localStorage.getItem('wrapline') === "no" ? false : true)
+  let [useE2EE, setUseE2EE] = useState<boolean>(useE2EEncryption())
   // @ts-ignore -- needed as TS thinks second localStorage.getItem() call would return null but it won't due to ternary
   let [fontSize, setFontSize] = useState<number>(localStorage.getItem('fontsize') === null ? 16 : parseInt(localStorage.getItem('fontsize')))
   // @ts-ignore -- needed as TS thinks second localStorage.getItem() call would return null but it won't due to ternary 
@@ -42,10 +43,10 @@ function App() {
   let [language, setLanguage] = useState<string>("plaintext")
   let [document, setDocument] = useState<string>("")
   let [selectedLanguage, setSelectedLanguage] = useState<Extension | undefined>()
-  let [ephCryptoStack, setEphCryptoStack] = useState<Promise<CryptoStack> | undefined>(undefined)
-  let [nonEphCryptoStack, setNonEphCryptoStack] = useState<Promise<CryptoStack> | undefined>(undefined)
   // Menubar (Mobile) State
   let [menubarVisible, setMenubarVisible] = useState<boolean>(false)
+  // Snippet State Properties
+  let [saveService, setSaveService] = useState<ServiceInterface | undefined>()
 
   useEffect(() => {
     localStorage.setItem('theme', theme)
@@ -53,22 +54,35 @@ function App() {
     localStorage.setItem('wrapline', wrapLine ? "yes" : "no")
   }, [wrapLine, fontSize, theme])
 
+  function useE2EEncryption() {
+    const hasWebKit = navigator.userAgent.includes('AppleWebKit');
+    const hasChrome = navigator.userAgent.includes('Chrome');
+    let usesWebKit = hasWebKit && !hasChrome;
+    if (!usesWebKit) {
+      const userDisabled = localStorage.getItem('use_e2ee') === "no";
+      const useE2EE = (!usesWebKit) && (!userDisabled)
+      return useE2EE
+    }
+    return !usesWebKit;
+  }
+
   // start generation of non-eph crypto stack if ephemeral is changed to false
   // we don't generate both by default to save compute an prevent slowdown
   useEffect(() => {
     if (generateStack) {
-      if (ephemeral) {
-        if (ephCryptoStack === undefined) {
-          setEphCryptoStack(generateEncryptionStack(true))
-        }
-      }
-      if (!ephemeral) {
-        if (nonEphCryptoStack === undefined) {
-          setNonEphCryptoStack(generateEncryptionStack(false))
+      if (saveService === undefined) {
+        switch (useE2EE) {
+          case true:
+            const svc = new E2EService(setAlert)
+            svc.initSave(ephemeral)
+            setSaveService(svc)
+            break
+          case false:
+            setSaveService(new RestService(setAlert))
         }
       }
     }
-  }, [ephemeral, ephCryptoStack, nonEphCryptoStack, generateStack])
+  }, [ephemeral, generateStack, saveService, useE2EE])
 
   useEffect(() => {
     if (alert === "") {
@@ -106,115 +120,130 @@ function App() {
     handleThemeChange(theme, setSelectedTheme)
   }, [theme]) // only runs when theme changes
 
-  useEffect(() => {
-    if (editorContainerRef.current) {
-      setEditorWidth(editorContainerRef.current.offsetWidth)
-    }
-  }) // runs continuously to ensure editor is full sized
-
-  const checkIfEphemeral = (id: string): boolean => {
-    return (id.match(/[A-Z]/g) || []).length === 2
-  }
-
+  // load snippet if param 'id' is present
+  // else trigger generation of encryption stack (if E2EE is enabled)
   useEffect(() => {
     if (params.id && document === "") {
       setReadOnly(true)
       setLoading(true)
-      // load snippet
-      setAlert("generating crypto stack")
-      getSnippetUUID(params.id).then(uuid => {
-        setAlert("downloading snippet")
-        // @ts-ignore
-        axios.get<SnippetSpecModel>(environment.S3BaseURL + (checkIfEphemeral(params.id) ? "ephemeral/" + uuid : uuid)).then(snippetSpec => {
-          setAlert("decrypting")
-          // @ts-ignore
-          aeadDecrypt(snippetSpec.data, params.id).then(snippet => {
-            setDocument(snippet.data)
-            setEphemeral(snippet.metadata.ephemeral)
-            setLanguage(snippet.metadata.language)
-            setLoading(false)
-          })
-        }).catch(e => {
-          setAlert(JSON.stringify(e.code))
-          console.log(e)
-          setTimeout(() => {
-            onDuplicateAndEdit()
-          }, 5000)
-        })
+      let snippetPromise = undefined
+      switch (useE2EE) {
+        case true:
+          const e2eloader = new E2EService(setAlert)
+          snippetPromise = e2eloader.load(params.id)
+          break
+        case false:
+          const restLoader = new RestService(setAlert)
+          snippetPromise = restLoader.load(params.id)
+      }
+      snippetPromise.then(snippet => {
+        setDocument(snippet.data)
+        setEphemeral(snippet.metadata.ephemeral)
+        setLanguage(snippet.metadata.language)
+        setLoading(false)
+      }).catch(e => {
+        console.log(e)
+        setAlert('something went wrong: ' + e)
+        setTimeout(() => {
+          onDuplicateAndEdit()
+          setLoading(false)
+        }, 5000)
       })
     } else {
-      setGenerateStack(true)
+      if (useE2EE) {
+        setGenerateStack(true)
+      }
     }
-  }, [params]) // used to load snippet if param 'id' is present
-
+  }, [])
 
   const onSave = () => {
     if (document === "" || document === "cannot save empty snippet!") {
       setAlert("cannot save empty snippet!")
       return
     }
+
+    if (saveService === undefined) {
+      return
+    }
+
     setLoading(true)
-    setAlert("generating crypto stack");
-    (ephemeral ? ephCryptoStack : nonEphCryptoStack)?.then(stack => {
-      setAlert("encypting")
-      aeadEncrypt({
-        data: document,
-        metadata: {
-          id: stack.snippetID,
-          language: language,
-          ephemeral: ephemeral
-        }
-      }, stack).then(snippetSpec => {
-        setAlert("saving")
-        axios.post(environment.APIBaseURL + "e2e/" + stack.uuid, snippetSpec, {
-          headers: {
-            'Ephemeral': ephemeral
-          }
-        }).then(() => {
-          navigate('/' + stack.snippetID, { replace: true })
-          setAlert("saved")
-          setReadOnly(true)
-          setLoading(false)
-        }).catch(e => {
-          setLoading(false)
-          setAlert(JSON.stringify(e.code))
-          console.log(e)
-        })
-      })
+    saveService.save({
+      data: document,
+      metadata: {
+        id: "placeholder",
+        language: language,
+        ephemeral: ephemeral
+      }
+    }).then(res => {
+      navigate('/' + res, { replace: true })
+      setAlert("saved")
+      setReadOnly(true)
+      setLoading(false)
+    }).catch(e => {
+      setLoading(false)
+      console.log(e)
+      setAlert('something went wrong: ' + e)
     })
   }
 
   const onDuplicateAndEdit = () => {
-    setEphCryptoStack(undefined)
-    setNonEphCryptoStack(undefined)
+    setSaveService(undefined)
     setReadOnly(false)
     navigate("..")
   }
 
-  const onDocumentChange = React.useCallback((value: string, viewUpdate: ViewUpdate) => {
+  // hook to enable window free-sizeing
+  let dimensions = useWindowDimensions()
+
+  // handle window width change
+  useEffect(() => {
+    setDesktopView(dimensions.width >= 1024)
+  }, [dimensions])
+
+  // handle window width change
+  useEffect(() => {
+    setEditorHeight(desktopView ? dimensions.height : dimensions.height - 60)
+    if (editorContainerRef.current) {
+      setEditorWidth(editorContainerRef.current.offsetWidth)
+    }
+  }, [desktopView, dimensions])
+
+  const updateDoc = React.useCallback((value: string) => {
     setDocument(value)
   }, []);
 
-  let dimensions = useWindowDimensions()
-
   return (
     <div>
-      {dimensions.width < 768 && <NavBar menubar={menubarVisible} setMenubarDisplay={setMenubarVisible} />}
+      {!desktopView && <NavBar menubar={menubarVisible} setMenubarDisplay={setMenubarVisible} />}
       <div className="flex">
-        {!menubarVisible && <div className="md:w-2/3 lg:w-3/4 xl:w-4/5 2xl:w-5/6 w-screen" ref={editorContainerRef} >
+        {!menubarVisible && <div className="lg:w-3/4 xl:w-4/5 2xl:w-5/6 w-screen" ref={editorContainerRef} >
           <CodeMirror
             autoFocus={true}
+            // value={JSON.stringify({ editor: { height: editorHeight, width: editorWidth } }) + '\n' + JSON.stringify({ window: { ...dimensions } })}
             value={document}
             readOnly={readOnly || loading}
             theme={selectedTheme}
             extensions={getExtensions()}
-            height={(dimensions.width >= 768 ? dimensions.height : dimensions.height - 60).toString() + 'px'}
+            height={editorHeight.toString() + 'px'}
             width={(editorWidth).toString() + 'px'}
-            onChange={onDocumentChange}
+            onChange={updateDoc}
           />
         </div>}
-        {(menubarVisible || dimensions.width >= 768) && <div className='w-full md:w-1/3 lg:w-1/4 xl:w-1/5 2xl:w-1/6'>
-          <MenuBar showBranding={!menubarVisible} duplicateAndEdit={onDuplicateAndEdit} id={readOnly ? params.id : undefined} alert={alert} loading={loading} readOnly={readOnly} save={onSave} ephemeral={{ ephemeral, setEphemeral }} language={{ language, setLanguage }} theme={{ theme, setTheme }} font={{ fontSize, setFontSize }} wrapLine={{ wrapLine, setWrapLine }} />
+        {(menubarVisible || desktopView) && <div className='lg:w-1/4 xl:w-1/5 2xl:w-1/6 w-full'>
+          <MenuBar showBranding={!menubarVisible} duplicateAndEdit={onDuplicateAndEdit} id={readOnly ? params.id : undefined} alert={alert} loading={loading} readOnly={readOnly} save={onSave} language={{ language, setLanguage }} theme={{ theme, setTheme }} font={{ fontSize, setFontSize }} wrapLine={{ wrapLine, setWrapLine }}
+            useE2EE={{
+              useE2EE, setUseE2EE: ((useE2EE => {
+                setSaveService(undefined)
+                localStorage.setItem('use_e2ee', useE2EE ? "yes" : "no")
+                setUseE2EE(useE2EE)
+              }))
+            }}
+            ephemeral={{
+              ephemeral, setEphemeral: (ephemeral => {
+                setSaveService(undefined)
+                setEphemeral(ephemeral)
+              })
+            }} />
         </div>}
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ function App() {
   let [alert, setAlert] = useState<string>('')
   let [dismisser, setDismisser] = useState<NodeJS.Timeout | undefined>()
   // Editor State Properties 
+  let [generateStack, setGenerateStack] = useState<boolean>(false)
   // TODO: Load and save to browser localStorage
   let [wrapLine, setWrapLine] = useState<boolean>(localStorage.getItem('wrapline') === "no" ? false : true)
   // @ts-ignore -- needed as TS thinks second localStorage.getItem() call would return null but it won't due to ternary
@@ -55,17 +56,19 @@ function App() {
   // start generation of non-eph crypto stack if ephemeral is changed to false
   // we don't generate both by default to save compute an prevent slowdown
   useEffect(() => {
-    if (ephemeral) {
-      if (ephCryptoStack === undefined) {
-        setEphCryptoStack(generateEncryptionStack(true))
+    if (generateStack) {
+      if (ephemeral) {
+        if (ephCryptoStack === undefined) {
+          setEphCryptoStack(generateEncryptionStack(true))
+        }
+      }
+      if (!ephemeral) {
+        if (nonEphCryptoStack === undefined) {
+          setNonEphCryptoStack(generateEncryptionStack(false))
+        }
       }
     }
-    if (!ephemeral) {
-      if (nonEphCryptoStack === undefined) {
-        setNonEphCryptoStack(generateEncryptionStack(false))
-      }
-    }
-  }, [ephemeral, ephCryptoStack, nonEphCryptoStack])
+  }, [ephemeral, ephCryptoStack, nonEphCryptoStack, generateStack])
 
   useEffect(() => {
     if (alert === "") {
@@ -139,6 +142,8 @@ function App() {
           }, 5000)
         })
       })
+    } else {
+      setGenerateStack(true)
     }
   }, [params]) // used to load snippet if param 'id' is present
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { duotoneDark } from '@uiw/codemirror-theme-duotone';
 import './App.css';
 
 import MenuBar from './menubar'
+import NavBar from './navbar/navbar'
 
 import getFontSizeThemeExtension from './fonts'
 import useWindowDimensions from './dimensions';
@@ -42,6 +43,8 @@ function App() {
   let [selectedLanguage, setSelectedLanguage] = useState<Extension | undefined>()
   let [ephCryptoStack, setEphCryptoStack] = useState<Promise<CryptoStack> | undefined>(undefined)
   let [nonEphCryptoStack, setNonEphCryptoStack] = useState<Promise<CryptoStack> | undefined>(undefined)
+  // Menubar (Mobile) State
+  let [menubarVisible, setMenubarVisible] = useState<boolean>(false)
 
   useEffect(() => {
     localStorage.setItem('theme', theme)
@@ -187,22 +190,27 @@ function App() {
     setDocument(value)
   }, []);
 
+  let dimensions = useWindowDimensions()
+
   return (
-    <div className="flex">
-      <div className="md:w-2/3 lg:w-3/4 xl:w-4/5 2xl:w-5/6 w-screen" ref={editorContainerRef} >
-        <CodeMirror
-          autoFocus={true}
-          value={document}
-          readOnly={readOnly || loading}
-          theme={selectedTheme}
-          extensions={getExtensions()}
-          height={(useWindowDimensions().height).toString() + 'px'}
-          width={(editorWidth).toString() + 'px'}
-          onChange={onDocumentChange}
-        />
-      </div>
-      <div className='md:block md:w-1/3 lg:w-1/4 xl:w-1/5 2xl:w-1/6 hidden'>
-        <MenuBar duplicateAndEdit={onDuplicateAndEdit} id={readOnly ? params.id : undefined} alert={alert} loading={loading} readOnly={readOnly} save={onSave} ephemeral={{ ephemeral, setEphemeral }} language={{ language, setLanguage }} theme={{ theme, setTheme }} font={{ fontSize, setFontSize }} wrapLine={{ wrapLine, setWrapLine }} />
+    <div>
+      {dimensions.width < 768 && <NavBar menubar={menubarVisible} setMenubarDisplay={setMenubarVisible} />}
+      <div className="flex">
+        {!menubarVisible && <div className="md:w-2/3 lg:w-3/4 xl:w-4/5 2xl:w-5/6 w-screen" ref={editorContainerRef} >
+          <CodeMirror
+            autoFocus={true}
+            value={document}
+            readOnly={readOnly || loading}
+            theme={selectedTheme}
+            extensions={getExtensions()}
+            height={(dimensions.width >= 768 ? dimensions.height : dimensions.height - 60).toString() + 'px'}
+            width={(editorWidth).toString() + 'px'}
+            onChange={onDocumentChange}
+          />
+        </div>}
+        {(menubarVisible || dimensions.width >= 768) && <div className='w-full md:w-1/3 lg:w-1/4 xl:w-1/5 2xl:w-1/6'>
+          <MenuBar showBranding={!menubarVisible} duplicateAndEdit={onDuplicateAndEdit} id={readOnly ? params.id : undefined} alert={alert} loading={loading} readOnly={readOnly} save={onSave} ephemeral={{ ephemeral, setEphemeral }} language={{ language, setLanguage }} theme={{ theme, setTheme }} font={{ fontSize, setFontSize }} wrapLine={{ wrapLine, setWrapLine }} />
+        </div>}
       </div>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,12 +142,27 @@ function App() {
         setLanguage(snippet.metadata.language)
         setLoading(false)
       }).catch(e => {
-        console.log(e)
-        setAlert('something went wrong: ' + e)
-        setTimeout(() => {
-          onDuplicateAndEdit()
-          setLoading(false)
-        }, 5000)
+        switch (e.response.status) {
+          case 403:
+          case 404:
+            setAlert('snippet not found')
+            setDocument('snippet not found')
+            setTimeout(() => {
+              onDuplicateAndEdit()
+              setLoading(false)
+              setDocument('')
+            }, 5000)
+            break;
+          default:
+            console.log(e)
+            setAlert('something went wrong: ' + e)
+            setDocument('something went wrong: ' + e)
+            setTimeout(() => {
+              onDuplicateAndEdit()
+              setLoading(false)
+              setDocument('')
+            }, 5000)
+        }
       })
     } else {
       if (useE2EE) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
   let [dismisser, setDismisser] = useState<NodeJS.Timeout | undefined>()
   let [desktopView, setDesktopView] = useState<boolean>(false)
   // Editor State Properties 
-  let [generateStack, setGenerateStack] = useState<boolean>(false)
+  let [saveMode, setSaveMode] = useState<boolean>(false)
   let [wrapLine, setWrapLine] = useState<boolean>(localStorage.getItem('wrapline') === "no" ? false : true)
   let [useE2EE, setUseE2EE] = useState<boolean>(useE2EEncryption())
   // @ts-ignore -- needed as TS thinks second localStorage.getItem() call would return null but it won't due to ternary
@@ -69,7 +69,7 @@ function App() {
   // start generation of non-eph crypto stack if ephemeral is changed to false
   // we don't generate both by default to save compute an prevent slowdown
   useEffect(() => {
-    if (generateStack) {
+    if (saveMode) {
       if (saveService === undefined) {
         switch (useE2EE) {
           case true:
@@ -82,7 +82,7 @@ function App() {
         }
       }
     }
-  }, [ephemeral, generateStack, saveService, useE2EE])
+  }, [ephemeral, saveMode, saveService, useE2EE])
 
   useEffect(() => {
     if (alert === "") {
@@ -165,9 +165,7 @@ function App() {
         }
       })
     } else {
-      if (useE2EE) {
-        setGenerateStack(true)
-      }
+      setSaveMode(true)
     }
   }, [])
 
@@ -194,6 +192,8 @@ function App() {
       setAlert("saved")
       setReadOnly(true)
       setLoading(false)
+      setSaveMode(false)
+      setSaveService(undefined)
     }).catch(e => {
       setLoading(false)
       console.log(e)
@@ -202,6 +202,7 @@ function App() {
   }
 
   const onDuplicateAndEdit = () => {
+    setSaveMode(true)
     setSaveService(undefined)
     setReadOnly(false)
     navigate("..")

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,6 +217,9 @@ function App() {
 
   // handle window width change
   useEffect(() => {
+    if (desktopView) {
+      setMenubarVisible(false)
+    }
     setEditorHeight(desktopView ? dimensions.height : dimensions.height - 60)
     if (editorContainerRef.current) {
       setEditorWidth(editorContainerRef.current.offsetWidth)

--- a/src/crypto/crypto.ts
+++ b/src/crypto/crypto.ts
@@ -3,6 +3,7 @@ import { hash as argon2 } from 'argon2-webworker'
 import pako from 'pako'
 import { Base64 } from 'js-base64'
 import { environment } from '../environment'
+import { SnippetModel, SnippetSpecModel } from '../model'
 
 
 export interface CryptoStack {
@@ -109,25 +110,6 @@ export function aeadEncrypt(snippet: SnippetModel, stack: CryptoStack): Promise<
             ephemeral: snippet.metadata.ephemeral
         })
     })
-}
-
-export interface SnippetSpecModel {
-    version: string
-    keysalt: string
-    ephemeral: boolean
-    initvector: string
-    ciphertext: string
-}
-
-export interface SnippetModel {
-    metadata: SnippetMetadataModel
-    data: string
-}
-
-interface SnippetMetadataModel {
-    id: string
-    language: string
-    ephemeral: boolean
 }
 
 export function aeadDecrypt(data: SnippetSpecModel, id: string): Promise<SnippetModel> {

--- a/src/menubar/index.tsx
+++ b/src/menubar/index.tsx
@@ -27,6 +27,7 @@ interface menubarProps {
   duplicateAndEdit: () => void
   loading: boolean
   readOnly: boolean
+  showBranding: boolean
   alert: string
 }
 
@@ -41,9 +42,9 @@ function MenuBar(props: menubarProps) {
   return (
     <Fragment>
       <div className="bg-gray-800 text-white h-screen">
-        <div className="p-8 bg-purple-800">
+        {props.showBranding && <div className="p-8 bg-purple-800">
           <a className="font-mono text-center text-2xl block" href="/">i/o/ctl</a>
-        </div>
+        </div>}
         <div>
           <h4 className="font-mono text-center text-xl pb-4 pt-6">Editor Options</h4>
           <div className="items-center px-8">
@@ -104,7 +105,7 @@ function MenuBar(props: menubarProps) {
           </div>
         </div>
         {props.id && <div className="flex space-x-2 justify-center mt-3">
-          <a type="button" href={environment.APIBaseURL+"r/"+props.id} className="inline-block w-5/6 px-6 py-2.5 bg-pink-700 text-center text-white font-medium text-xs leading-tight uppercase rounded shadow-lg hover:bg-purple-700 hover:shadow-lg focus:bg-purple-700 focus:shadow-lg focus:outline-none focus:ring-0 active:bg-blue-800 active:shadow-lg transition duration-150 ease-in-out" >
+          <a type="button" href={environment.APIBaseURL + "r/" + props.id} className="inline-block w-5/6 px-6 py-2.5 bg-pink-700 text-center text-white font-medium text-xs leading-tight uppercase rounded shadow-lg hover:bg-purple-700 hover:shadow-lg focus:bg-purple-700 focus:shadow-lg focus:outline-none focus:ring-0 active:bg-blue-800 active:shadow-lg transition duration-150 ease-in-out" >
             raw
           </a>
         </div>}

--- a/src/menubar/index.tsx
+++ b/src/menubar/index.tsx
@@ -123,8 +123,8 @@ function MenuBar(props: menubarProps) {
             <span>{props.alert}</span>
           </div>}
         <div>
-          <a className="font-mono text-center text-l mt-4 mb-3 cursor-pointer block" href="/About">ℹ️ About</a>
-          <a className="font-mono text-center text-l my-3  cursor-pointer block" href="https://github.com/fitant" target="_blank">GitHub</a>
+          <a className="font-mono text-center text-l mt-4 mb-3 cursor-pointer block" href="/About">About</a>
+          <a className="font-mono text-center text-l my-3  cursor-pointer block" href="https://github.com/sid-sun/ioctl" target="_blank">GitHub</a>
           <a className="font-mono text-center text-l my-3 cursor-pointer block" href="/PrivacyPolicy">Privacy Policy</a>
         </div>
       </div>

--- a/src/menubar/index.tsx
+++ b/src/menubar/index.tsx
@@ -22,6 +22,10 @@ interface menubarProps {
     ephemeral: boolean
     setEphemeral: (arg0: boolean) => void
   }
+  useE2EE: {
+    useE2EE: boolean
+    setUseE2EE: (arg0: boolean) => void
+  }
   id?: string
   save: () => void
   duplicateAndEdit: () => void
@@ -38,6 +42,7 @@ function MenuBar(props: menubarProps) {
   let { language, setLanguage } = props.language
   let { wrapLine, setWrapLine } = props.wrapLine
   let { ephemeral, setEphemeral } = props.ephemeral
+  let { useE2EE, setUseE2EE } = props.useE2EE
 
   return (
     <Fragment>
@@ -61,9 +66,13 @@ function MenuBar(props: menubarProps) {
             <br />
             <input onChange={e => setFontSize(parseInt(e.target.value))} value={fontSize} type="range" id="fontSize" max="26" min="10" step="1" className="w-full form-check-input" />
           </div>
-          <div className="items-stretch form-check px-8 py-3">
+          <div className="items-stretch form-check px-8 mt-1">
             <input checked={wrapLine} onChange={() => setWrapLine(!wrapLine)} type="checkbox" id="wordwrap" className="form-check-input" />
             <label htmlFor="wordwrap" className="text-center font-mono pl-2">Wrap Text</label>
+          </div>
+          <div className="items-stretch form-check px-8 mt-1 pb-3">
+            <input checked={useE2EE} onChange={() => setUseE2EE(!useE2EE)} type="checkbox" id="useE2EE" className="form-check-input" />
+            <label htmlFor="useE2EE" className="text-center font-mono pl-2">Use E2EE</label>
           </div>
           <h4 className="font-mono text-center text-xl py-4">Snippet Options</h4>
           <div className="items-center form-check pb-0 px-8">

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,0 +1,18 @@
+export interface SnippetModel {
+    metadata: SnippetMetadataModel
+    data: string
+}
+
+interface SnippetMetadataModel {
+    id: string
+    language: string
+    ephemeral: boolean
+}
+
+export interface SnippetSpecModel {
+    version: string
+    keysalt: string
+    ephemeral: boolean
+    initvector: string
+    ciphertext: string
+}

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+interface navbarProps {
+    menubar: boolean
+    setMenubarDisplay: (arg0: boolean) => void
+}
+
+function navbar(props: navbarProps) {
+    return (
+        <React.Fragment>
+            <nav className="relative w-full flex flex-wrap items-center justify-between py-4 bg-purple-800 text-white">
+                <div className="container-fluid w-full flex flex-wrap items-center justify-between px-6">
+                    <div className="container-fluid">
+                        <a className="font-mono text-center text-xl block" href="/">i/o/ctl</a>
+                    </div>
+                    <a onClick={() => props.setMenubarDisplay(!props.menubar)} className="font-mono text-center text-xl block">menu</a>
+                </div>
+            </nav>
+        </React.Fragment>
+
+    )
+}
+
+export default navbar

--- a/src/navbar/navbar.tsx
+++ b/src/navbar/navbar.tsx
@@ -13,7 +13,7 @@ function navbar(props: navbarProps) {
                     <div className="container-fluid">
                         <a className="font-mono text-center text-xl block" href="/">i/o/ctl</a>
                     </div>
-                    <a onClick={() => props.setMenubarDisplay(!props.menubar)} className="font-mono text-center text-xl block">menu</a>
+                    <a onClick={() => props.setMenubarDisplay(!props.menubar)} className="font-mono text-center text-xl block">{props.menubar ? 'editor' : 'menu'}</a>
                 </div>
             </nav>
         </React.Fragment>

--- a/src/service/e2e.ts
+++ b/src/service/e2e.ts
@@ -1,0 +1,69 @@
+import axios from "axios";
+import { aeadDecrypt, aeadEncrypt, CryptoStack, generateEncryptionStack, getSnippetUUID } from "../crypto/crypto";
+import { environment } from "../environment";
+import { SnippetModel, SnippetSpecModel } from "../model";
+import { ServiceInterface } from "./model";
+
+export class E2EService implements ServiceInterface {
+    cryptoStack: Promise<CryptoStack> | undefined
+    setAlert: (message: string) => void
+
+    save(snippet: SnippetModel) {
+        const setAlert = this.setAlert
+        return new Promise<string>(async (resolve, reject) => {
+            setAlert("generating crypto stack");
+            if (this.cryptoStack === undefined) {
+                reject('crypto stack not initialised')
+                return
+            }
+            this.cryptoStack.then(stack => {
+                snippet.metadata.id = stack.snippetID
+                setAlert("encypting")
+                aeadEncrypt(snippet, stack).then(snippetSpec => {
+                    setAlert("saving")
+                    return axios.post(environment.APIBaseURL + "e2e/" + stack.uuid, snippetSpec, {
+                        headers: {
+                            'Ephemeral': snippet.metadata.ephemeral
+                        }
+                    }).then(() => {
+                        resolve(stack.snippetID)
+                    }).catch(e => {
+                        reject(e)
+                    })
+                })
+            })
+        })
+    };
+
+    private checkIfEphemeral(id: string) {
+        return (id.match(/[A-Z]/g) || []).length === 2
+    }
+
+    load(id: string) {
+        const setAlert = this.setAlert
+        setAlert("generating crypto stack")
+        return new Promise<SnippetModel>(async (resolve, reject) => {
+            getSnippetUUID(id).then(uuid => {
+                setAlert("downloading snippet")
+                axios.get<SnippetSpecModel>(environment.S3BaseURL + (this.checkIfEphemeral(id) ? "ephemeral/" + uuid : uuid)).then(snippetSpec => {
+                    setAlert("decrypting")
+                    aeadDecrypt(snippetSpec.data, id).then(snippet => {
+                        resolve(snippet)
+                    })
+                }).catch(e => {
+                    reject(e)
+                })
+            })
+        })
+    };
+
+    initSave(ephemeral: boolean) {
+        if (this.cryptoStack === undefined) {
+            this.cryptoStack = generateEncryptionStack(ephemeral)
+        }
+    }
+
+    constructor(setAlert: (message: string) => void) {
+        this.setAlert = setAlert
+    }
+}

--- a/src/service/model.ts
+++ b/src/service/model.ts
@@ -1,0 +1,6 @@
+import { SnippetModel } from "../model"
+
+export interface ServiceInterface {
+    save: (snipet: SnippetModel) => Promise<string>
+    load: (id: string) => Promise<SnippetModel>
+}

--- a/src/service/rest.ts
+++ b/src/service/rest.ts
@@ -1,0 +1,44 @@
+import axios from "axios";
+import { environment } from "../environment";
+import { SnippetModel } from "../model";
+import { ServiceInterface } from "./model";
+
+interface CreateResponse {
+    URL: string
+}
+
+export class RestService implements ServiceInterface {
+    setAlert: (message: string) => void
+
+    save(snippet: SnippetModel) {
+        const setAlert = this.setAlert
+        return new Promise<string>(async (resolve, reject) => {
+            setAlert('saving snippet')
+            axios.post(environment.APIBaseURL, snippet).then((res) => {
+                const data: CreateResponse = res.data
+                const urlParts = data.URL.split('/')
+                const id = urlParts[urlParts.length - 1]
+                resolve(id)
+            }).catch(e => {
+                reject(e)
+            })
+        })
+    };
+
+    load(id: string) {
+        const setAlert = this.setAlert
+        return new Promise<SnippetModel>(async (resolve, reject) => {
+            setAlert('downloading snippet')
+            axios.get(environment.APIBaseURL + id).then((res) => {
+                const data: SnippetModel = res.data
+                resolve(data)
+            }).catch(e => {
+                reject(e)
+            })
+        })
+    };
+
+    constructor(setAlert: (message: string) => void) {
+        this.setAlert = setAlert
+    }
+}


### PR DESCRIPTION
Safari and WebKit based browsers tend to inexplicably kill web worker responsible for argon2 stack generation to get around this, e2ee is now optional (it may still be enabled on safari however it won't work reliably)

Web App now works reliably on mobile and table too and shows alerts on the editor when loading a snippet (this is needed as menubar alerts are not visiable to user when loading a snippet on mobile) however editor sizing breaks on iPads when rotating back and forth; however it still remains usable

ARGON2 Encryption Stack is now handled in a better fashion, manged entirely by its own E2E Service and is only generated when needed, reducing unneeded computation

Rest Service is introduced as an alternative to E2E service (naming is not perfect as E2E does use REST for saving snippets) through interface, making the app less directly dependent on E2E and reduces number of dependencies added on App module (although there remains room for improvement)

E2E or Rest Service are both loaded on initial load but it will be possible to do dynamic loading of these components

