### PR TITLE
Add support for snippet spec v2

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -16,3 +16,8 @@ export interface SnippetSpecModel {
     initvector: string
     ciphertext: string
 }
+
+export enum SnippetSpecVersion {
+    v1 = "v1",
+    v2 = "v2",
+}

--- a/src/service/e2e.ts
+++ b/src/service/e2e.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { aeadDecrypt, aeadEncrypt, CryptoStack, generateEncryptionStack, getSnippetUUID } from "../crypto/crypto";
 import { environment } from "../environment";
-import { SnippetModel, SnippetSpecModel } from "../model";
+import { SnippetModel, SnippetSpecModel, SnippetSpecVersion } from "../model";
 import { ServiceInterface } from "./model";
 
 export class E2EService implements ServiceInterface {
@@ -47,7 +47,8 @@ export class E2EService implements ServiceInterface {
                 setAlert("downloading snippet")
                 axios.get<SnippetSpecModel>(environment.S3BaseURL + (this.checkIfEphemeral(id) ? "ephemeral/" + uuid : uuid)).then(snippetSpec => {
                     setAlert("decrypting")
-                    aeadDecrypt(snippetSpec.data, id).then(snippet => {
+                    const version = snippetSpec.data.version === SnippetSpecVersion.v2 ? SnippetSpecVersion.v2 : SnippetSpecVersion.v1;
+                    aeadDecrypt(snippetSpec.data, id, version).then(snippet => {
                         resolve(snippet)
                     })
                 }).catch(e => {


### PR DESCRIPTION
Spec v2 changes how snippet object is handled in create and fetch flows, specifically:
during creation:

    Compress user Snippet instead of entire object then B64 encode it
    during fetch:
    After decryption, unmarshal data to snippet to object then run B64 decode and decompression on snippet's data field

Advantages to this approach:

    Compression is cleaner and more effective as we only want to target user snippet; compressing JSON doesn't have any clear benefit and might be less effective due to noise
    Running B64 on compressed data prevents JSON Marshal from producing a large output for non-text data due to encoding challenges (think: escapes) thus improving memory usage and reducing size of these JSON encoded objects quite dramatically

Backwards compatibility is preserved for existing v1 snippets; however no new snippets will be created with it. REST API spec remains unchanged as it only relies on snippet object and that remains changed